### PR TITLE
Hotfix reverse scanner [PLPL-5959]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,8 +186,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>com.factual</groupId>
     <artifactId>haeinsa</artifactId>
-    <version>1.0.5.10-factual</version>
+    <version>1.0.5.11-factual-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>haeinsa</name>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>com.factual</groupId>
     <artifactId>haeinsa</artifactId>
-    <version>1.0.5.11-factual-SNAPSHOT</version>
+    <version>1.0.5.11-factual</version>
     <packaging>jar</packaging>
 
     <name>haeinsa</name>

--- a/pom.xml
+++ b/pom.xml
@@ -483,16 +483,19 @@
             </build>
         </profile>
     </profiles>
-  <repositories>
-    <repository>
-      <id>cloudera</id>
-      <url>https://repository.cloudera.com/artifactory/cloudera-repos</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-    </repository>
-  </repositories>
+    <repositories>
+        <repository>
+            <id>foursquare</id>
+            <url>https://foursquaredev.jfrog.io/foursquaredev/fsnexus</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>foursquare</id>
+            <url>https://foursquaredev.jfrog.io/foursquaredev/fsnexus</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
 </project>

--- a/src/main/java/kr/co/vcnc/haeinsa/HaeinsaKeyValue.java
+++ b/src/main/java/kr/co/vcnc/haeinsa/HaeinsaKeyValue.java
@@ -58,8 +58,8 @@ public class HaeinsaKeyValue {
         public int compare(HaeinsaKeyValue o1, HaeinsaKeyValue o2) {
             return ComparisonChain.start()
                 .compare(o2.getRow(), o1.getRow(), new NullableComparator<>(Bytes.BYTES_COMPARATOR))
-                .compare(o2.getFamily(), o1.getFamily(), new NullableComparator<>(Bytes.BYTES_COMPARATOR))
-                .compare(o2.getQualifier(), o1.getQualifier(), new NullableComparator<>(Bytes.BYTES_COMPARATOR))
+                .compare(o1.getFamily(), o2.getFamily(), new NullableComparator<>(Bytes.BYTES_COMPARATOR))
+                .compare(o1.getQualifier(), o2.getQualifier(), new NullableComparator<>(Bytes.BYTES_COMPARATOR))
                 .compare(o2.getType().getCode() & 0xFF, o1.getType().getCode() & 0xFF)
                 .result();
         }

--- a/src/main/java/kr/co/vcnc/haeinsa/HaeinsaKeyValue.java
+++ b/src/main/java/kr/co/vcnc/haeinsa/HaeinsaKeyValue.java
@@ -53,6 +53,18 @@ public class HaeinsaKeyValue {
         }
     };
 
+    public static final Comparator<HaeinsaKeyValue> REVERSE_COMPARATOR = new Comparator<HaeinsaKeyValue>() {
+        @Override
+        public int compare(HaeinsaKeyValue o1, HaeinsaKeyValue o2) {
+            return ComparisonChain.start()
+                .compare(o2.getRow(), o1.getRow(), new NullableComparator<>(Bytes.BYTES_COMPARATOR))
+                .compare(o2.getFamily(), o1.getFamily(), new NullableComparator<>(Bytes.BYTES_COMPARATOR))
+                .compare(o2.getQualifier(), o1.getQualifier(), new NullableComparator<>(Bytes.BYTES_COMPARATOR))
+                .compare(o2.getType().getCode() & 0xFF, o1.getType().getCode() & 0xFF)
+                .result();
+        }
+    };
+
     private byte[] row;
     private byte[] family;
     private byte[] qualifier;

--- a/src/main/java/kr/co/vcnc/haeinsa/HaeinsaKeyValueScanner.java
+++ b/src/main/java/kr/co/vcnc/haeinsa/HaeinsaKeyValueScanner.java
@@ -48,7 +48,7 @@ public interface HaeinsaKeyValueScanner {
         @Override
         public int compare(HaeinsaKeyValueScanner o1, HaeinsaKeyValueScanner o2) {
             return ComparisonChain.start()
-                    .compare(o2.peek(), o1.peek(), HaeinsaKeyValue.COMPARATOR)
+                    .compare(o1.peek(), o2.peek(), HaeinsaKeyValue.REVERSE_COMPARATOR)
                     .compare(o1.getSequenceID(), o2.getSequenceID())
                     .result();
         }

--- a/src/test/java/kr/co/vcnc/haeinsa/HaeinsaKeyValueScannerTest.java
+++ b/src/test/java/kr/co/vcnc/haeinsa/HaeinsaKeyValueScannerTest.java
@@ -79,6 +79,11 @@ public class HaeinsaKeyValueScannerTest {
 
     @Override
     public void close() {}
+
+    @Override
+    public String toString() {
+      return peek().toString();
+    }
   }
 
 }

--- a/src/test/java/kr/co/vcnc/haeinsa/HaeinsaKeyValueScannerTest.java
+++ b/src/test/java/kr/co/vcnc/haeinsa/HaeinsaKeyValueScannerTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import kr.co.vcnc.haeinsa.thrift.generated.TRowLock;
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.util.Bytes;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -12,7 +13,6 @@ import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static kr.co.vcnc.haeinsa.HaeinsaKeyValueTest.bytes;
 import static kr.co.vcnc.haeinsa.HaeinsaKeyValueTest.shuffleCopy;
 
 public class HaeinsaKeyValueScannerTest {
@@ -37,7 +37,7 @@ public class HaeinsaKeyValueScannerTest {
       sorted = Lists.reverse(sorted);
     }
     List<HaeinsaKeyValueScanner> expected = sorted.stream()
-        .map(row -> new SimpleScanner(new HaeinsaKeyValue(bytes(row), bytes("family"), bytes("qualifier"), bytes(row), KeyValue.Type.Put)))
+        .map(row -> new SimpleScanner(new HaeinsaKeyValue(Bytes.toBytes(row), Bytes.toBytes("family"), Bytes.toBytes("qualifier"), Bytes.toBytes(row), KeyValue.Type.Put)))
         .collect(Collectors.toList());
 
     List<HaeinsaKeyValueScanner> actual = shuffleCopy(expected);

--- a/src/test/java/kr/co/vcnc/haeinsa/HaeinsaKeyValueScannerTest.java
+++ b/src/test/java/kr/co/vcnc/haeinsa/HaeinsaKeyValueScannerTest.java
@@ -1,0 +1,84 @@
+package kr.co.vcnc.haeinsa;
+
+import com.google.common.collect.Lists;
+import kr.co.vcnc.haeinsa.thrift.generated.TRowLock;
+import org.apache.commons.lang.NotImplementedException;
+import org.apache.hadoop.hbase.KeyValue;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static kr.co.vcnc.haeinsa.HaeinsaKeyValueTest.bytes;
+import static kr.co.vcnc.haeinsa.HaeinsaKeyValueTest.shuffleCopy;
+
+public class HaeinsaKeyValueScannerTest {
+
+  @DataProvider(name = "comparator-provider")
+  public Object[][] comparatorProvider() {
+    return new Object[][]{{HaeinsaKeyValueScanner.COMPARATOR, false}, {HaeinsaKeyValueScanner.REVERSE_COMPARATOR, true}};
+  }
+
+  @Test(dataProvider = "comparator-provider")
+  public void testComparatorTypeOrdering(Comparator<HaeinsaKeyValueScanner> comparator, boolean reverse) {
+    List<HaeinsaKeyValueScanner> expected = toScanner(HaeinsaKeyValueTest.sameRowFamilyQualifierAllTypes());
+    List<HaeinsaKeyValueScanner> actual = shuffleCopy(expected);
+    actual.sort(comparator);
+    Assert.assertEquals(actual, expected);
+  }
+
+  @Test(dataProvider = "comparator-provider")
+  public void testComparatorRowOrdering(Comparator<HaeinsaKeyValueScanner> comparator, boolean reverse) {
+    List<String> sorted = Arrays.asList("a", "b", "c", "d");
+    if (reverse) {
+      sorted = Lists.reverse(sorted);
+    }
+    List<HaeinsaKeyValueScanner> expected = sorted.stream()
+        .map(row -> new SimpleScanner(new HaeinsaKeyValue(bytes(row), bytes("family"), bytes("qualifier"), bytes(row), KeyValue.Type.Put)))
+        .collect(Collectors.toList());
+
+    List<HaeinsaKeyValueScanner> actual = shuffleCopy(expected);
+    actual.sort(comparator);
+    Assert.assertEquals(actual, expected);
+  }
+
+  List<HaeinsaKeyValueScanner> toScanner(List<HaeinsaKeyValue> values) {
+    return values.stream().map(SimpleScanner::new).collect(Collectors.toList());
+  }
+
+  private static class SimpleScanner implements HaeinsaKeyValueScanner {
+
+    private final HaeinsaKeyValue value;
+
+    private SimpleScanner(HaeinsaKeyValue value) {
+      this.value = value;
+    }
+
+    @Override
+    public HaeinsaKeyValue peek() {
+      return value;
+    }
+
+    @Override
+    public HaeinsaKeyValue next() throws IOException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public TRowLock peekLock() {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public long getSequenceID() {
+      return 0;
+    }
+
+    @Override
+    public void close() {}
+  }
+
+}

--- a/src/test/java/kr/co/vcnc/haeinsa/HaeinsaKeyValueTest.java
+++ b/src/test/java/kr/co/vcnc/haeinsa/HaeinsaKeyValueTest.java
@@ -1,11 +1,11 @@
 package kr.co.vcnc.haeinsa;
 
 import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.util.Bytes;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -31,12 +31,8 @@ public class HaeinsaKeyValueTest {
 
   public static List<HaeinsaKeyValue> sameRowFamilyQualifierAllTypes() {
     return TRAVERSAL_ORDER.stream()
-        .map(type -> new HaeinsaKeyValue(bytes("row"), bytes("family"), bytes("qualifier"), bytes(type.toString()), type))
+        .map(type -> new HaeinsaKeyValue(Bytes.toBytes("row"), Bytes.toBytes("family"), Bytes.toBytes("qualifier"), Bytes.toBytes(type.toString()), type))
         .collect(Collectors.toList());
-  }
-
-  public static byte[] bytes(String s) {
-    return s.getBytes(StandardCharsets.UTF_8);
   }
 
   public static <T> List<T> shuffleCopy(List<T> items) {

--- a/src/test/java/kr/co/vcnc/haeinsa/HaeinsaKeyValueTest.java
+++ b/src/test/java/kr/co/vcnc/haeinsa/HaeinsaKeyValueTest.java
@@ -1,0 +1,45 @@
+package kr.co.vcnc.haeinsa;
+
+import org.apache.hadoop.hbase.KeyValue;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+import static org.apache.hadoop.hbase.KeyValue.Type.*;
+
+public class HaeinsaKeyValueTest {
+  private static final List<KeyValue.Type> TRAVERSAL_ORDER = Arrays.asList(Maximum, DeleteFamily, DeleteColumn, DeleteFamilyVersion, Delete, Put, Minimum);
+
+  @Test
+  public void testComparatorTypeOrdering() {
+    comparatorTypeOrdering(HaeinsaKeyValue.COMPARATOR);
+  }
+
+  @Test
+  public void testReverseTypeOrdering() {
+    comparatorTypeOrdering(HaeinsaKeyValue.REVERSE_COMPARATOR);
+  }
+
+  public void comparatorTypeOrdering(Comparator<HaeinsaKeyValue> comparator) {
+    List<HaeinsaKeyValue> expected = sameRowFamilyQualifierAllTypes();
+    List<HaeinsaKeyValue> actual = new ArrayList<>(expected);
+
+    Collections.sort(actual, comparator);
+
+    Assert.assertEquals(actual, expected);
+  }
+
+  List<HaeinsaKeyValue> sameRowFamilyQualifierAllTypes() {
+    ArrayList<HaeinsaKeyValue> all = new ArrayList<>();
+    for (KeyValue.Type type : TRAVERSAL_ORDER) {
+      all.add(new HaeinsaKeyValue(bytes("row"), bytes("family"), bytes("qualifier"), bytes(type.toString()), type));
+    }
+    return all;
+  }
+
+  private byte[] bytes(String s) {
+    return s.getBytes(StandardCharsets.UTF_8);
+  }
+}

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,7 @@
+log4j.rootLogger=INFO, console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{ABSOLUTE} %5p %C{1} - %m%n
+
+log4j.logger.SecurityLogger=WARN


### PR DESCRIPTION
The bug was that the reverse scanner would sort the family deletes and the column deletes after the puts and the logic would think the put was still valid and return it and the deletes would be ignored in certain cases.

I couldn't get a good unit test that reproduced this in `HaeinsaUnitTest` so only create some simple tests with the comparators.